### PR TITLE
Update duckdb scripts to match latest clickbench runner

### DIFF
--- a/common/run-query-duckdb.py
+++ b/common/run-query-duckdb.py
@@ -11,8 +11,6 @@ if __name__ == "__main__":
     print(query)
 
     con = duckdb.connect(database="my-db.duckdb", read_only=False)
-    # enable parquet metadata cache
-    con.execute("PRAGMA enable_object_cache")
 
     # invoke like run-duckdb-query.py 1 << "txt of q1"
     query_num = sys.argv[1]


### PR DESCRIPTION
I was having a hard time reproducing the results with DuckDB

I finally found that using the object_cache slows queries down on subsequent queries, making duckdb look worse than it is. 

It looks like they removed this setting in the clickbench script as well: https://github.com/ClickHouse/ClickBench/commit/60bd91fe6ef56ae306985072f32c153ed3caa60b

So update our scripts to follow