### PR TITLE
use `fetch_arrow_table` instead of `fetchall` for DuckDB

### DIFF
--- a/common/run-query-duckdb.py
+++ b/common/run-query-duckdb.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
             # set number of cores
             con.execute("PRAGMA threads={}".format(c))
             start = timeit.default_timer()
-            result = con.execute(query).fetchall()
+            result = con.execute(query).fetch_arrow_table()
             end = timeit.default_timer()
             print(end-start)
 


### PR DESCRIPTION
As described here:

https://github.com/apache/arrow-datafusion/issues/6782#issuecomment-1832775559